### PR TITLE
Create React frontend scaffold with core guild pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+frontend/node_modules/
+frontend/dist/
+.DS_Store

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Guild Website Draft</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.55",
+    "@types/react-dom": "^18.2.19",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,34 @@
+import { Route, Routes } from 'react-router-dom';
+import Layout from './components/Layout';
+import Home from './pages/Home';
+import Events from './pages/Events';
+import Vault from './pages/Vault';
+import Placeholder from './pages/Placeholder';
+import NotFound from './pages/NotFound';
+
+const App = () => {
+  return (
+    <Routes>
+      <Route element={<Layout />}>
+        <Route path="/" element={<Home />} />
+        <Route path="/events" element={<Events />} />
+        <Route path="/vault" element={<Vault />} />
+        <Route
+          path="/community"
+          element={<Placeholder title="Community" description="Community hub coming soon." />}
+        />
+        <Route
+          path="/resources"
+          element={<Placeholder title="Resources" description="Resource library coming soon." />}
+        />
+        <Route
+          path="/contact"
+          element={<Placeholder title="Contact" description="Contact channels coming soon." />}
+        />
+        <Route path="*" element={<NotFound />} />
+      </Route>
+    </Routes>
+  );
+};
+
+export default App;

--- a/frontend/src/components/BackToTopButton.tsx
+++ b/frontend/src/components/BackToTopButton.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+const BackToTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 320);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  const handleClick = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <button
+      type="button"
+      className={`back-to-top ${isVisible ? 'is-visible' : ''}`}
+      onClick={handleClick}
+      aria-label="Back to top"
+    >
+      ↑
+    </button>
+  );
+};
+
+export default BackToTopButton;

--- a/frontend/src/components/EventCalendar.tsx
+++ b/frontend/src/components/EventCalendar.tsx
@@ -1,0 +1,41 @@
+import { EventItem } from '../data/events';
+
+interface EventCalendarProps {
+  events: EventItem[];
+  onSelect: (event: EventItem) => void;
+}
+
+const dayLabels = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+const EventCalendar = ({ events, onSelect }: EventCalendarProps) => {
+  const eventsByDay = dayLabels.map((_, index) =>
+    events.filter(event => new Date(event.date).getDay() === index).sort((a, b) => a.date.localeCompare(b.date)),
+  );
+
+  return (
+    <div className="event-calendar" role="grid" aria-label="Event calendar">
+      {dayLabels.map((label, index) => (
+        <div key={label} className="event-calendar__column" role="gridcell" aria-label={label}>
+          <p className="event-calendar__day">{label}</p>
+          {eventsByDay[index].length === 0 ? (
+            <p className="event-calendar__empty">No scheduled events</p>
+          ) : (
+            eventsByDay[index].map(event => (
+              <button
+                key={event.id}
+                type="button"
+                className="event-calendar__event"
+                onClick={() => onSelect(event)}
+              >
+                <span className="event-calendar__event-title">{event.title}</span>
+                <span className="event-calendar__event-time">{event.time}</span>
+              </button>
+            ))
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default EventCalendar;

--- a/frontend/src/components/EventList.tsx
+++ b/frontend/src/components/EventList.tsx
@@ -1,0 +1,37 @@
+import { EventItem } from '../data/events';
+
+interface EventListProps {
+  events: EventItem[];
+  onSelect: (event: EventItem) => void;
+}
+
+const EventList = ({ events, onSelect }: EventListProps) => {
+  return (
+    <ul className="event-list">
+      {events.map(event => (
+        <li key={event.id} className="event-list__item">
+          <article>
+            <p className="event-list__date">
+              {new Date(event.date).toLocaleDateString(undefined, {
+                month: 'long',
+                day: 'numeric',
+                year: 'numeric',
+              })}
+            </p>
+            <h3>{event.title}</h3>
+            <p className="event-list__meta">
+              <span>{event.time}</span>
+              <span>{event.location}</span>
+            </p>
+            <p>{event.summary}</p>
+            <button type="button" className="link-button" onClick={() => onSelect(event)}>
+              View details
+            </button>
+          </article>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default EventList;

--- a/frontend/src/components/EventOverlay.tsx
+++ b/frontend/src/components/EventOverlay.tsx
@@ -1,0 +1,35 @@
+import { EventItem } from '../data/events';
+
+interface EventOverlayProps {
+  event: EventItem | null;
+  onClose: () => void;
+}
+
+const EventOverlay = ({ event, onClose }: EventOverlayProps) => {
+  if (!event) return null;
+
+  return (
+    <div className="event-overlay" role="dialog" aria-modal="true" aria-labelledby="event-overlay-title">
+      <div className="event-overlay__backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="event-overlay__content">
+        <button type="button" className="event-overlay__close" onClick={onClose} aria-label="Close details">
+          ×
+        </button>
+        <p className="event-overlay__eyebrow">Event spotlight</p>
+        <h3 id="event-overlay-title">{event.title}</h3>
+        <p className="event-overlay__meta">
+          <span>{new Date(event.date).toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' })}</span>
+          <span>{event.time}</span>
+          <span>{event.location}</span>
+        </p>
+        <p className="event-overlay__summary">{event.summary}</p>
+        <p>{event.description}</p>
+        <button type="button" className="cta-button">
+          Add to calendar
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EventOverlay;

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,49 @@
+import useScrollReveal from '../hooks/useScrollReveal';
+
+const Footer = () => {
+  const footerRef = useScrollReveal<HTMLElement>({ threshold: 0.2 });
+
+  return (
+    <footer ref={footerRef} className="site-footer" aria-label="Footer">
+      <div className="site-footer__inner">
+        <div>
+          <h3>Guild Collective</h3>
+          <p>
+            Designing better member experiences through collaboration, shared learning, and purposeful experiments.
+          </p>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <ul>
+            <li>
+              <a href="#">Guild HQ</a>
+            </li>
+            <li>
+              <a href="#">Chapters</a>
+            </li>
+            <li>
+              <a href="#">Press kit</a>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h4>Connect</h4>
+          <ul>
+            <li>
+              <a href="#">Slack</a>
+            </li>
+            <li>
+              <a href="#">Newsletter</a>
+            </li>
+            <li>
+              <a href="#">Support</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <p className="site-footer__note">© {new Date().getFullYear()} Guild Collective. All rights reserved.</p>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/frontend/src/components/HeroCarousel.tsx
+++ b/frontend/src/components/HeroCarousel.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useState } from 'react';
+import { heroSlides } from '../data/heroSlides';
+
+const accentClassMap = {
+  crimson: 'hero-slide--crimson',
+  gold: 'hero-slide--gold',
+  slate: 'hero-slide--slate',
+} as const;
+
+const HeroCarousel = () => {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const slides = useMemo(() => heroSlides, []);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setActiveIndex(prev => (prev + 1) % slides.length);
+    }, 7000);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [slides.length]);
+
+  const handleSelect = (index: number) => {
+    setActiveIndex(index);
+  };
+
+  const activeSlide = slides[activeIndex];
+
+  return (
+    <section className="hero" aria-label="Featured guild highlights">
+      <div className={`hero-slide ${accentClassMap[activeSlide.accent]}`}>
+        <div className="hero-slide__content">
+          <p className="hero-slide__eyebrow">Guild Collective</p>
+          <h1>{activeSlide.title}</h1>
+          <p>{activeSlide.description}</p>
+          <button type="button" className="hero-slide__cta">
+            {activeSlide.cta}
+          </button>
+        </div>
+        <div className="hero-slide__controls" role="tablist" aria-label="Hero slides">
+          {slides.map((slide, index) => (
+            <button
+              key={slide.id}
+              type="button"
+              role="tab"
+              aria-selected={index === activeIndex}
+              aria-label={`View slide ${index + 1}: ${slide.title}`}
+              className={index === activeIndex ? 'is-active' : ''}
+              onClick={() => handleSelect(index)}
+            >
+              <span aria-hidden="true">{index + 1}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HeroCarousel;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,25 @@
+import { Outlet } from 'react-router-dom';
+import Navigation from './Navigation';
+import HeroCarousel from './HeroCarousel';
+import ServiceHighlights from './ServiceHighlights';
+import UpdatesSection from './UpdatesSection';
+import Footer from './Footer';
+import BackToTopButton from './BackToTopButton';
+
+const Layout = () => {
+  return (
+    <div className="app-shell">
+      <Navigation />
+      <HeroCarousel />
+      <main className="page-content" id="main-content">
+        <Outlet />
+      </main>
+      <ServiceHighlights />
+      <UpdatesSection />
+      <Footer />
+      <BackToTopButton />
+    </div>
+  );
+};
+
+export default Layout;

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -1,0 +1,42 @@
+import { NavLink } from 'react-router-dom';
+import SearchBar from './SearchBar';
+
+const Navigation = () => {
+  return (
+    <header className="site-header">
+      <div className="site-header__inner">
+        <NavLink to="/" className="site-logo">
+          <span className="site-logo__mark">G</span>
+          <span className="site-logo__text">Guild Collective</span>
+        </NavLink>
+        <nav aria-label="Primary">
+          <ul className="site-nav">
+            <li>
+              <NavLink to="/" end>
+                Home
+              </NavLink>
+            </li>
+            <li>
+              <NavLink to="/events">Events</NavLink>
+            </li>
+            <li>
+              <NavLink to="/vault">Vault</NavLink>
+            </li>
+            <li>
+              <NavLink to="/community">Community</NavLink>
+            </li>
+            <li>
+              <NavLink to="/resources">Resources</NavLink>
+            </li>
+            <li>
+              <NavLink to="/contact">Contact</NavLink>
+            </li>
+          </ul>
+        </nav>
+        <SearchBar placeholder="Search site" />
+      </div>
+    </header>
+  );
+};
+
+export default Navigation;

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,0 +1,35 @@
+import { FormEvent, useId, useState } from 'react';
+
+interface SearchBarProps {
+  placeholder?: string;
+  variant?: 'light' | 'dark';
+}
+
+const SearchBar = ({ placeholder = 'Search the guild', variant = 'light' }: SearchBarProps) => {
+  const [value, setValue] = useState('');
+  const inputId = useId();
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+  };
+
+  return (
+    <form className={`search-bar search-bar--${variant}`} onSubmit={handleSubmit} role="search">
+      <label className="visually-hidden" htmlFor={inputId}>
+        Search
+      </label>
+      <input
+        id={inputId}
+        type="search"
+        placeholder={placeholder}
+        value={value}
+        onChange={event => setValue(event.target.value)}
+      />
+      <button type="submit" aria-label="Submit search">
+        <span aria-hidden="true">⌕</span>
+      </button>
+    </form>
+  );
+};
+
+export default SearchBar;

--- a/frontend/src/components/ServiceHighlights.tsx
+++ b/frontend/src/components/ServiceHighlights.tsx
@@ -1,0 +1,31 @@
+import useScrollReveal from '../hooks/useScrollReveal';
+import { serviceHighlights } from '../data/serviceHighlights';
+
+const ServiceHighlights = () => {
+  const sectionRef = useScrollReveal<HTMLElement>();
+
+  return (
+    <section ref={sectionRef} className="section service-highlights" aria-labelledby="service-highlights-heading">
+      <div className="section__header">
+        <p className="section__eyebrow">What we offer</p>
+        <h2 id="service-highlights-heading">Service highlights</h2>
+        <p className="section__lead">
+          Signature programs that keep members experimenting, learning, and shipping meaningful work together.
+        </p>
+      </div>
+      <div className="service-grid">
+        {serviceHighlights.map(highlight => (
+          <article key={highlight.id} className="service-card">
+            <h3>{highlight.name}</h3>
+            <p>{highlight.summary}</p>
+            <button type="button" className="link-button">
+              {highlight.linkLabel}
+            </button>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ServiceHighlights;

--- a/frontend/src/components/UpdatesSection.tsx
+++ b/frontend/src/components/UpdatesSection.tsx
@@ -1,0 +1,31 @@
+import useScrollReveal from '../hooks/useScrollReveal';
+import { updates } from '../data/updates';
+
+const UpdatesSection = () => {
+  const sectionRef = useScrollReveal<HTMLElement>();
+
+  return (
+    <section ref={sectionRef} className="section updates" aria-labelledby="updates-heading">
+      <div className="section__header">
+        <p className="section__eyebrow">Stay in the loop</p>
+        <h2 id="updates-heading">Latest updates</h2>
+        <p className="section__lead">Announcements and spotlights from across the guild network.</p>
+      </div>
+      <div className="updates-grid">
+        {updates.map(update => (
+          <article key={update.id} className="update-card">
+            <p className="update-card__category">{update.category}</p>
+            <h3>{update.title}</h3>
+            <p className="update-card__date">{update.date}</p>
+            <p>{update.description}</p>
+            <button type="button" className="link-button">
+              Read more
+            </button>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default UpdatesSection;

--- a/frontend/src/data/events.ts
+++ b/frontend/src/data/events.ts
@@ -1,0 +1,52 @@
+export type EventItem = {
+  id: number;
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  summary: string;
+  description: string;
+};
+
+export const events: EventItem[] = [
+  {
+    id: 1,
+    title: 'Strategy Roundtable',
+    date: '2024-04-11',
+    time: '10:00 AM – 11:30 AM ET',
+    location: 'Virtual',
+    summary: 'Member strategy leads share their quarterly OKRs and request cross-team input.',
+    description:
+      'Join facilitators from across chapters for a focused roundtable on member strategy. Bring one challenge that needs guild feedback and leave with actionable advice.',
+  },
+  {
+    id: 2,
+    title: 'Design Ops Clinic',
+    date: '2024-04-17',
+    time: '2:00 PM – 3:15 PM ET',
+    location: 'Guild HQ, Studio 4',
+    summary: 'Live working session to streamline briefs and handoffs for the innovation studio teams.',
+    description:
+      'Our design ops leads are opening up their playbooks. Expect hands-on activities focused on simplifying the guild request intake process and clarifying success metrics.',
+  },
+  {
+    id: 3,
+    title: 'Community Showcase',
+    date: '2024-04-23',
+    time: '6:00 PM – 7:30 PM ET',
+    location: 'Hybrid',
+    summary: 'Celebrate project launches with lightning talks from three chapters and member Q&A.',
+    description:
+      'An energizing evening featuring chapter demo booths, live lightning talks, and an AMA with the leadership council. Bring guests and questions!',
+  },
+  {
+    id: 4,
+    title: 'Vault Curators AMA',
+    date: '2024-04-29',
+    time: '12:00 PM – 1:00 PM ET',
+    location: 'Virtual',
+    summary: 'Meet the curators stewarding new vault submissions and learn how to contribute.',
+    description:
+      'Hear directly from the curators about submission guidelines, evaluation criteria, and upcoming thematic collections. Plenty of time for questions and shared inspiration.',
+  },
+];

--- a/frontend/src/data/heroSlides.ts
+++ b/frontend/src/data/heroSlides.ts
@@ -1,0 +1,31 @@
+export type HeroSlide = {
+  id: number;
+  title: string;
+  description: string;
+  cta: string;
+  accent: 'crimson' | 'gold' | 'slate';
+};
+
+export const heroSlides: HeroSlide[] = [
+  {
+    id: 1,
+    title: 'Guild Innovations Hub',
+    description: 'Collaborate on cross-discipline initiatives that shape the next generation of member services.',
+    cta: 'Explore the guild roadmap',
+    accent: 'crimson',
+  },
+  {
+    id: 2,
+    title: 'Events That Bring Us Together',
+    description: 'From strategy roundtables to community showcases, there is always something on the calendar.',
+    cta: 'View the events calendar',
+    accent: 'gold',
+  },
+  {
+    id: 3,
+    title: 'Resource Vault',
+    description: 'A curated archive of playbooks, templates, and insights from guild chapters across the globe.',
+    cta: 'Preview the vault collection',
+    accent: 'slate',
+  },
+];

--- a/frontend/src/data/serviceHighlights.ts
+++ b/frontend/src/data/serviceHighlights.ts
@@ -1,0 +1,27 @@
+export type ServiceHighlight = {
+  id: number;
+  name: string;
+  summary: string;
+  linkLabel: string;
+};
+
+export const serviceHighlights: ServiceHighlight[] = [
+  {
+    id: 1,
+    name: 'Mentorship Circles',
+    summary: 'Connect with domain experts each quarter for guided cohort sessions and peer accountability.',
+    linkLabel: 'Meet the mentors',
+  },
+  {
+    id: 2,
+    name: 'Innovation Studio',
+    summary: 'Rapid prototyping lab for validating member experience ideas with real guild feedback.',
+    linkLabel: 'Tour the studio',
+  },
+  {
+    id: 3,
+    name: 'Learning Tracks',
+    summary: 'Curated playlists of workshops, recordings, and playbooks to expand your guild toolkit.',
+    linkLabel: 'Browse tracks',
+  },
+];

--- a/frontend/src/data/updates.ts
+++ b/frontend/src/data/updates.ts
@@ -1,0 +1,31 @@
+export type UpdateItem = {
+  id: number;
+  title: string;
+  date: string;
+  description: string;
+  category: 'Announcement' | 'Spotlight' | 'Reminder';
+};
+
+export const updates: UpdateItem[] = [
+  {
+    id: 1,
+    title: 'Quarterly Summit Registration Open',
+    date: 'April 02, 2024',
+    description: 'Secure your seat for the hybrid summit featuring member-led case studies and live design critiques.',
+    category: 'Announcement',
+  },
+  {
+    id: 2,
+    title: 'Spotlight: Chapter Beta',
+    date: 'March 24, 2024',
+    description: 'See how Chapter Beta accelerated onboarding by pairing new members with guild alumni.',
+    category: 'Spotlight',
+  },
+  {
+    id: 3,
+    title: 'Resource Vault Refresh',
+    date: 'March 18, 2024',
+    description: 'New templates added for strategic planning, monthly reporting, and member journey mapping.',
+    category: 'Reminder',
+  },
+];

--- a/frontend/src/hooks/useScrollReveal.ts
+++ b/frontend/src/hooks/useScrollReveal.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react';
+
+type RevealOptions = {
+  threshold?: number;
+  rootMargin?: string;
+};
+
+const useScrollReveal = <T extends HTMLElement>({ threshold = 0.15, rootMargin = '0px' }: RevealOptions = {}) => {
+  const ref = useRef<T | null>(null);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+          }
+        });
+      },
+      { threshold, rootMargin },
+    );
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [threshold, rootMargin]);
+
+  return ref;
+};
+
+export default useScrollReveal;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/Events.tsx
+++ b/frontend/src/pages/Events.tsx
@@ -1,0 +1,72 @@
+import { useMemo, useState } from 'react';
+import { events as eventsData, EventItem } from '../data/events';
+import EventCalendar from '../components/EventCalendar';
+import EventList from '../components/EventList';
+import EventOverlay from '../components/EventOverlay';
+import SearchBar from '../components/SearchBar';
+import useScrollReveal from '../hooks/useScrollReveal';
+
+type EventsView = 'calendar' | 'list';
+
+const Events = () => {
+  const [view, setView] = useState<EventsView>('calendar');
+  const [selectedEvent, setSelectedEvent] = useState<EventItem | null>(null);
+  const introRef = useScrollReveal<HTMLElement>({ threshold: 0.2 });
+  const boardRef = useScrollReveal<HTMLElement>({ threshold: 0.25 });
+
+  const events = useMemo(() => eventsData.slice().sort((a, b) => a.date.localeCompare(b.date)), []);
+
+  const handleViewChange = (nextView: EventsView) => {
+    setView(nextView);
+  };
+
+  const handleSelectEvent = (event: EventItem) => {
+    setSelectedEvent(event);
+  };
+
+  const handleCloseOverlay = () => {
+    setSelectedEvent(null);
+  };
+
+  return (
+    <div className="page events-page">
+      <section ref={introRef} className="page-section">
+        <div className="page-section__header">
+          <h2>Events</h2>
+          <p>Choose your view to browse upcoming gatherings, clinics, and community spotlights.</p>
+        </div>
+        <SearchBar placeholder="Search events" variant="dark" />
+        <div className="view-toggle" role="tablist" aria-label="Event view options">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === 'calendar'}
+            className={view === 'calendar' ? 'is-active' : ''}
+            onClick={() => handleViewChange('calendar')}
+          >
+            Calendar view
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === 'list'}
+            className={view === 'list' ? 'is-active' : ''}
+            onClick={() => handleViewChange('list')}
+          >
+            List view
+          </button>
+        </div>
+      </section>
+      <section ref={boardRef} className="page-section">
+        {view === 'calendar' ? (
+          <EventCalendar events={events} onSelect={handleSelectEvent} />
+        ) : (
+          <EventList events={events} onSelect={handleSelectEvent} />
+        )}
+      </section>
+      <EventOverlay event={selectedEvent} onClose={handleCloseOverlay} />
+    </div>
+  );
+};
+
+export default Events;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,37 @@
+import useScrollReveal from '../hooks/useScrollReveal';
+
+const Home = () => {
+  const introRef = useScrollReveal<HTMLElement>({ threshold: 0.25 });
+  const focusRef = useScrollReveal<HTMLElement>({ threshold: 0.2 });
+
+  return (
+    <div className="page home-page">
+      <section ref={introRef} className="page-section">
+        <h2>Welcome to the Guild Collective</h2>
+        <p>
+          We are a distributed network of practitioners obsessed with building remarkable member experiences. Explore our
+          programs, attend an upcoming event, and contribute to the shared resource vault.
+        </p>
+      </section>
+      <section ref={focusRef} className="page-section page-section--accent">
+        <h3>Focus areas this season</h3>
+        <ul className="focus-list">
+          <li>
+            <h4>Member Journey Mapping</h4>
+            <p>Deep dives on onboarding improvements and ways to sustain engagement beyond the first 90 days.</p>
+          </li>
+          <li>
+            <h4>Experiment Design</h4>
+            <p>Shared frameworks for piloting programs with measurable impact on member retention and satisfaction.</p>
+          </li>
+          <li>
+            <h4>Chapter Enablement</h4>
+            <p>Toolkits that help each chapter operate autonomously while staying aligned on guild-wide goals.</p>
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default Home;

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,12 @@
+const NotFound = () => {
+  return (
+    <div className="page not-found-page">
+      <section className="page-section">
+        <h2>Page not found</h2>
+        <p>The page you are looking for has moved or no longer exists. Use the navigation to continue exploring.</p>
+      </section>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/frontend/src/pages/Placeholder.tsx
+++ b/frontend/src/pages/Placeholder.tsx
@@ -1,0 +1,24 @@
+import useScrollReveal from '../hooks/useScrollReveal';
+
+interface PlaceholderProps {
+  title: string;
+  description: string;
+}
+
+const Placeholder = ({ title, description }: PlaceholderProps) => {
+  const sectionRef = useScrollReveal<HTMLElement>({ threshold: 0.3 });
+
+  return (
+    <div className="page placeholder-page">
+      <section ref={sectionRef} className="page-section">
+        <h2>{title}</h2>
+        <p>{description}</p>
+        <p className="placeholder-note">
+          We are actively collecting member stories and program materials to shape this space. Check back soon!
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default Placeholder;

--- a/frontend/src/pages/Vault.tsx
+++ b/frontend/src/pages/Vault.tsx
@@ -1,0 +1,46 @@
+import SearchBar from '../components/SearchBar';
+import useScrollReveal from '../hooks/useScrollReveal';
+
+const Vault = () => {
+  const introRef = useScrollReveal<HTMLElement>({ threshold: 0.25 });
+  const collectionRef = useScrollReveal<HTMLElement>({ threshold: 0.2 });
+
+  return (
+    <div className="page vault-page">
+      <section ref={introRef} className="page-section">
+        <div className="page-section__header">
+          <h2>Vault</h2>
+          <p>A living library of templates, recordings, and shared playbooks from every corner of the guild.</p>
+        </div>
+        <SearchBar placeholder="Search vault" variant="dark" />
+      </section>
+      <section ref={collectionRef} className="page-section">
+        <div className="vault-grid">
+          <article className="vault-card">
+            <h3>Strategy Playbooks</h3>
+            <p>Quarterly planning canvases, scenario planning worksheets, and success metric dashboards.</p>
+            <button type="button" className="link-button">
+              Preview collection
+            </button>
+          </article>
+          <article className="vault-card">
+            <h3>Workshop Kits</h3>
+            <p>Facilitation guides, slide decks, and activity boards ready for your next chapter meetup.</p>
+            <button type="button" className="link-button">
+              Explore kits
+            </button>
+          </article>
+          <article className="vault-card">
+            <h3>Member Journey Library</h3>
+            <p>Annotated blueprints for onboarding, retention plays, and surprise-and-delight moments.</p>
+            <button type="button" className="link-button">
+              View blueprints
+            </button>
+          </article>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default Vault;

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,698 @@
+:root {
+  color-scheme: light;
+  --color-background: #ffffff;
+  --color-foreground: #0b1120;
+  --color-muted: #5b6475;
+  --color-border: rgba(11, 17, 32, 0.12);
+  --color-crimson: #c1121f;
+  --color-crimson-soft: #fcebec;
+  --color-gold: #f1c40f;
+  --color-gold-soft: #fff7d6;
+  --color-slate: #1f2937;
+  --color-slate-soft: #e3e8f4;
+  --color-surface: #f8f8fb;
+  --shadow-soft: 0 18px 40px rgba(12, 16, 31, 0.08);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.app-shell {
+  min-height: 100vh;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 1) 0%, rgba(249, 251, 255, 1) 100%);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem clamp(1.5rem, 4vw, 3rem);
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 1.125rem;
+  letter-spacing: 0.02em;
+}
+
+.site-logo__mark {
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: var(--color-crimson);
+  color: var(--color-background);
+  font-weight: 700;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.site-nav a {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 500;
+  color: var(--color-muted);
+}
+
+.site-nav a.active,
+.site-nav a:hover {
+  color: var(--color-foreground);
+  background: rgba(193, 18, 31, 0.12);
+}
+
+.search-bar {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.search-bar input {
+  border: none;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.95rem;
+  background: transparent;
+  outline: none;
+  color: inherit;
+  min-width: 12rem;
+}
+
+.search-bar button {
+  border: none;
+  background: transparent;
+  padding: 0.35rem 0.85rem;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--color-muted);
+}
+
+.search-bar--dark {
+  border-color: rgba(255, 255, 255, 0.24);
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+}
+
+.search-bar--dark input {
+  color: inherit;
+}
+
+.hero {
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.5rem, 6vw, 5rem);
+}
+
+.hero-slide {
+  position: relative;
+  border-radius: 2rem;
+  padding: clamp(2rem, 6vw, 4rem);
+  color: var(--color-background);
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-slide::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.35), transparent 45%);
+  pointer-events: none;
+}
+
+.hero-slide--crimson {
+  background: linear-gradient(135deg, var(--color-crimson), #640d14);
+}
+
+.hero-slide--gold {
+  background: linear-gradient(135deg, var(--color-gold), #c49b06);
+}
+
+.hero-slide--slate {
+  background: linear-gradient(135deg, var(--color-slate), #111827);
+}
+
+.hero-slide__content {
+  position: relative;
+  z-index: 1;
+  max-width: 34rem;
+}
+
+.hero-slide__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  margin-bottom: 1rem;
+  opacity: 0.8;
+}
+
+.hero-slide h1 {
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  margin-bottom: 1rem;
+}
+
+.hero-slide p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+.hero-slide__cta {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--color-foreground);
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.hero-slide__controls {
+  position: absolute;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.hero-slide__controls button {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(255, 255, 255, 0.28);
+  color: var(--color-background);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.hero-slide__controls button.is-active {
+  background: #ffffff;
+  color: var(--color-foreground);
+}
+
+.page-content {
+  padding: 0 clamp(1.5rem, 6vw, 4rem);
+}
+
+.page {
+  max-width: 72rem;
+  margin: 0 auto;
+}
+
+.page-section {
+  background: var(--color-background);
+  border-radius: 1.5rem;
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
+  box-shadow: 0 12px 32px rgba(12, 16, 31, 0.06);
+  border: 1px solid rgba(193, 18, 31, 0.05);
+  opacity: 0;
+  transform: translateY(32px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.page-section.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.page-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.page-section--accent {
+  background: linear-gradient(140deg, var(--color-crimson-soft), #fff);
+}
+
+.focus-list {
+  display: grid;
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0;
+}
+
+.focus-list li {
+  border-left: 4px solid var(--color-crimson);
+  padding-left: 1rem;
+}
+
+.focus-list h4 {
+  margin: 0 0 0.5rem;
+}
+
+.section {
+  padding: clamp(3rem, 8vw, 5rem) clamp(1.5rem, 6vw, 5rem);
+  opacity: 0;
+  transform: translateY(45px);
+  transition: opacity 0.7s ease, transform 0.7s ease;
+}
+
+.section.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.section__header {
+  max-width: 44rem;
+  margin-bottom: 2rem;
+}
+
+.section__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.8rem;
+  margin-bottom: 0.75rem;
+  color: rgba(193, 18, 31, 0.75);
+}
+
+.section__lead {
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 1.5rem;
+}
+
+.service-card {
+  background: var(--color-background);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(193, 18, 31, 0.1);
+  box-shadow: 0 16px 40px rgba(12, 16, 31, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.link-button {
+  align-self: flex-start;
+  border: none;
+  background: transparent;
+  color: var(--color-crimson);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.updates-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: 1.5rem;
+}
+
+.update-card {
+  background: var(--color-background);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(31, 41, 55, 0.08);
+  box-shadow: 0 16px 32px rgba(17, 24, 39, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.update-card__category {
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: rgba(193, 18, 31, 0.75);
+}
+
+.update-card__date {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.view-toggle {
+  display: inline-flex;
+  background: var(--color-slate-soft);
+  border-radius: 999px;
+  padding: 0.35rem;
+  margin-top: 1.5rem;
+  gap: 0.5rem;
+}
+
+.view-toggle button {
+  border: none;
+  background: transparent;
+  padding: 0.5rem 1.15rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--color-muted);
+}
+
+.view-toggle button.is-active {
+  background: var(--color-background);
+  color: var(--color-foreground);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
+}
+
+.event-calendar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 1rem;
+}
+
+.event-calendar__column {
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.9), #ffffff);
+  border-radius: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(31, 41, 55, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 14rem;
+}
+
+.event-calendar__day {
+  font-weight: 600;
+  color: var(--color-foreground);
+}
+
+.event-calendar__event {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  cursor: pointer;
+  background: var(--color-crimson-soft);
+  color: var(--color-foreground);
+}
+
+.event-calendar__event:hover {
+  background: rgba(193, 18, 31, 0.25);
+}
+
+.event-calendar__empty {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.event-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.event-list__item article {
+  border-radius: 1rem;
+  border: 1px solid rgba(31, 41, 55, 0.12);
+  padding: 1.5rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), #fff5f5);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.event-list__date {
+  font-weight: 600;
+  color: var(--color-crimson);
+}
+
+.event-list__meta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.event-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 100;
+}
+
+.event-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(11, 17, 32, 0.6);
+}
+
+.event-overlay__content {
+  position: relative;
+  background: #ffffff;
+  color: var(--color-foreground);
+  border-radius: 1.5rem;
+  padding: clamp(2rem, 4vw, 3rem);
+  width: min(90vw, 32rem);
+  box-shadow: 0 24px 56px rgba(12, 16, 31, 0.2);
+  display: grid;
+  gap: 1rem;
+  animation: overlayIn 0.35s ease;
+}
+
+.event-overlay__eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  color: rgba(193, 18, 31, 0.75);
+}
+
+.event-overlay__meta {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.event-overlay__summary {
+  font-weight: 600;
+}
+
+.event-overlay__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(0, 0, 0, 0.05);
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
+.cta-button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--color-crimson);
+  color: var(--color-background);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.vault-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: 1.5rem;
+}
+
+.vault-card {
+  background: linear-gradient(180deg, rgba(31, 41, 55, 0.08), rgba(255, 255, 255, 0.95));
+  padding: 1.75rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(31, 41, 55, 0.12);
+  box-shadow: 0 14px 28px rgba(17, 24, 39, 0.08);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.placeholder-note {
+  color: var(--color-muted);
+  border-left: 4px solid var(--color-crimson);
+  padding-left: 1rem;
+}
+
+.site-footer {
+  background: var(--color-slate);
+  color: #f9fafb;
+  padding: clamp(2rem, 4vw, 3rem) clamp(1.5rem, 5vw, 4rem);
+  margin-top: clamp(2rem, 6vw, 4rem);
+  opacity: 0;
+  transform: translateY(60px);
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+.site-footer.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.site-footer__inner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.site-footer h3,
+.site-footer h4 {
+  margin: 0 0 0.75rem;
+}
+
+.site-footer ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.site-footer a {
+  color: #f9fafb;
+}
+
+.site-footer__note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.back-to-top {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  background: var(--color-crimson);
+  color: var(--color-background);
+  border: none;
+  cursor: pointer;
+  font-size: 1.5rem;
+  display: grid;
+  place-items: center;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 200;
+}
+
+.back-to-top.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes overlayIn {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 960px) {
+  .site-header__inner {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .site-nav {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .hero-slide__controls {
+    position: static;
+    margin-top: 2rem;
+  }
+
+  .page-section__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 1.5rem;
+  }
+
+  .hero-slide {
+    border-radius: 1.5rem;
+  }
+
+  .page-section {
+    padding: 1.5rem;
+  }
+
+  .view-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .search-bar input {
+    min-width: 8rem;
+  }
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- initialize a Vite + React + TypeScript frontend project under `frontend/` with routing and configuration
- add shared layout elements including navigation, hero carousel, highlights, updates feed, animated footer, and back-to-top control
- implement Home, Events, Vault, and placeholder pages with search inputs, events calendar/list toggle, and overlay detail stubs

## Testing
- npm install *(fails: npm error 403 Forbidden - registry access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d300ce90e08326a257f879a207e08c