### PR TITLE
Add FastAPI backend with events endpoints

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,8 @@
+"""Backend application package for the Guild website."""
+
+__all__ = [
+    "config",
+    "database",
+    "main",
+    "models",
+]

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,49 @@
+"""API routers for the backend application."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from .database import get_session
+from .models import Event, EventCreate, EventRead
+
+router = APIRouter(prefix="/api/events", tags=["events"])
+
+
+@router.get("", response_model=List[EventRead])
+async def list_events(session: AsyncSession = Depends(get_session)) -> List[EventRead]:
+    """Return all events ordered by their event date."""
+
+    statement = select(Event).order_by(Event.date)
+    result = await session.execute(statement)
+    events = result.scalars().all()
+    return events
+
+
+@router.post("", response_model=EventRead, status_code=status.HTTP_201_CREATED)
+async def create_event(
+    event_in: EventCreate, session: AsyncSession = Depends(get_session)
+) -> EventRead:
+    """Create a new event after validating the input payload."""
+
+    event = Event(**event_in.dict())
+    session.add(event)
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unable to create event due to a database constraint violation.",
+        ) from exc
+
+    await session.refresh(event)
+    return event
+
+
+__all__ = ["router"]

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,106 @@
+"""Application configuration using environment variables.
+
+This module provides a :class:`Settings` object that reads configuration
+from environment variables, including helpers for DigitalOcean Managed
+PostgreSQL instances.  The settings can be injected into FastAPI routes
+using dependency injection for improved testability.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+from urllib.parse import quote_plus
+
+from pydantic import BaseSettings, Field, validator
+
+
+class Settings(BaseSettings):
+    """Runtime configuration loaded from environment variables."""
+
+    database_url: Optional[str] = Field(
+        default=None,
+        description="Full async database URL, overrides DigitalOcean specific settings.",
+        env="DATABASE_URL",
+    )
+    do_db_host: Optional[str] = Field(default=None, env="DO_DB_HOST")
+    do_db_port: int = Field(default=25060, env="DO_DB_PORT")
+    do_db_name: Optional[str] = Field(default=None, env="DO_DB_DATABASE")
+    do_db_user: Optional[str] = Field(default=None, env="DO_DB_USER")
+    do_db_password: Optional[str] = Field(default=None, env="DO_DB_PASSWORD")
+    do_db_sslmode: str = Field(default="require", env="DO_DB_SSLMODE")
+    db_echo: bool = Field(default=False, env="DB_ECHO")
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = False
+
+    @validator("do_db_sslmode")
+    def _validate_sslmode(cls, value: str) -> str:  # noqa: D401
+        """Validate the SSL mode value expected by PostgreSQL."""
+
+        allowed = {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}
+        if value not in allowed:
+            raise ValueError(
+                "Invalid DO_DB_SSLMODE; expected one of " + ", ".join(sorted(allowed))
+            )
+        return value
+
+    @property
+    def async_database_url(self) -> str:
+        """Return an asyncpg-compatible database URL.
+
+        If ``DATABASE_URL`` is supplied, it will be coerced to use the
+        ``asyncpg`` driver if necessary.  Otherwise, the method will build a
+        connection string tailored for DigitalOcean Managed PostgreSQL using
+        the DigitalOcean-specific environment variables.
+        """
+
+        if self.database_url:
+            return self._ensure_async_driver(self.database_url)
+
+        required_fields = {
+            "DO_DB_HOST": self.do_db_host,
+            "DO_DB_DATABASE": self.do_db_name,
+            "DO_DB_USER": self.do_db_user,
+            "DO_DB_PASSWORD": self.do_db_password,
+        }
+        missing = [name for name, value in required_fields.items() if not value]
+        if missing:
+            raise ValueError(
+                "Incomplete DigitalOcean PostgreSQL configuration; missing: "
+                + ", ".join(missing)
+            )
+
+        user = quote_plus(self.do_db_user or "")
+        password = quote_plus(self.do_db_password or "")
+        return (
+            f"postgresql+asyncpg://{user}:{password}@{self.do_db_host}:{self.do_db_port}/"
+            f"{self.do_db_name}?sslmode={self.do_db_sslmode}"
+        )
+
+    @staticmethod
+    def _ensure_async_driver(url: str) -> str:
+        """Ensure the SQLAlchemy URL uses the ``asyncpg`` driver."""
+
+        if url.startswith("postgresql+asyncpg://"):
+            return url
+        if url.startswith("postgresql://"):
+            return url.replace("postgresql://", "postgresql+asyncpg://", 1)
+        if url.startswith("postgres://"):
+            return url.replace("postgres://", "postgresql+asyncpg://", 1)
+        raise ValueError("Unsupported database URL scheme for async PostgreSQL: %s" % url)
+
+
+def get_settings() -> Settings:
+    """Return a cached :class:`Settings` instance for dependency injection."""
+
+    return _get_cached_settings()
+
+
+@lru_cache()
+def _get_cached_settings() -> Settings:
+    return Settings()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,54 @@
+"""Database helpers and session management for the FastAPI app."""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator, Optional
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+from .config import Settings, get_settings
+
+_async_engine: Optional[AsyncEngine] = None
+_sessionmaker: Optional[async_sessionmaker[AsyncSession]] = None
+
+
+def get_engine(settings: Settings) -> AsyncEngine:
+    """Create (or return) the shared async engine instance."""
+
+    global _async_engine, _sessionmaker
+    if _async_engine is None:
+        _async_engine = create_async_engine(settings.async_database_url, echo=settings.db_echo, future=True)
+        _sessionmaker = async_sessionmaker(
+            _async_engine,
+            expire_on_commit=False,
+            class_=AsyncSession,
+        )
+    return _async_engine
+
+
+async def init_db() -> None:
+    """Initialise the database by creating tables if necessary."""
+
+    settings = get_settings()
+    engine = get_engine(settings)
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+
+async def get_session(
+    settings: Settings = Depends(get_settings),
+) -> AsyncGenerator[AsyncSession, None]:
+    """Provide a database session via dependency injection."""
+
+    global _sessionmaker
+    if _sessionmaker is None:
+        get_engine(settings)
+    assert _sessionmaker is not None  # For type checkers
+
+    async with _sessionmaker() as session:
+        yield session
+
+
+__all__ = ["get_engine", "get_session", "init_db"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,33 @@
+"""FastAPI application entry-point for the Guild backend."""
+
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI
+
+from . import api
+from .config import Settings, get_settings
+from .database import init_db
+
+app = FastAPI(title="Guild Events API", version="1.0.0")
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    """Initialise the database once the application starts."""
+
+    await init_db()
+
+
+@app.get("/health", tags=["health"])
+async def health_check(settings: Settings = Depends(get_settings)) -> dict[str, str]:
+    """Simple endpoint to confirm the application is running."""
+
+    # Accessing settings ensures that dependency injection works and configuration is valid.
+    _ = settings.async_database_url
+    return {"status": "ok"}
+
+
+app.include_router(api.router)
+
+
+__all__ = ["app"]

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,59 @@
+"""Database models and Pydantic schemas for the FastAPI application."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import Column, DateTime, Numeric, Text
+from sqlalchemy.sql import func
+from sqlmodel import Field, SQLModel
+
+
+class EventBase(SQLModel):
+    """Shared fields across Event models."""
+
+    title: str = Field(max_length=200, description="Name of the event")
+    date: datetime = Field(description="Date and time when the event takes place")
+    location: str = Field(max_length=255, description="Venue or city for the event")
+    description: str = Field(sa_column=Column(Text), description="Detailed description")
+    price: Decimal = Field(
+        ge=0,
+        sa_column=Column(Numeric(10, 2), nullable=False),
+        description="Ticket price in the venue's local currency",
+    )
+
+
+class Event(EventBase, table=True):
+    """SQLModel table representing an event."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=False,
+            server_default=func.now(),
+        ),
+        description="Timestamp when the event was created",
+    )
+
+
+class EventCreate(EventBase):
+    """Payload used when creating a new event."""
+
+    pass
+
+
+class EventRead(EventBase):
+    """Response model for returning events to clients."""
+
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+__all__ = ["Event", "EventCreate", "EventRead"]


### PR DESCRIPTION
## Summary
- add FastAPI application under `backend/` with startup health check and router wiring
- define SQLModel models and Pydantic schemas for events with validation
- configure async PostgreSQL access using environment-driven settings for DigitalOcean

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d300d087008326b8e12892e1dd69d4